### PR TITLE
Support ancient (pre-1.6) Django versions

### DIFF
--- a/request_profiler/models.py
+++ b/request_profiler/models.py
@@ -16,11 +16,18 @@ logger = logging.getLogger(__name__)
 
 class RuleSetManager(models.Manager):
     """Custom model manager for RuleSet instances."""
+    def get_queryset_compat(self):
+        # Support the Django get_query_set -> get_queryset API change
+        get_queryset = (self.get_query_set
+                        if hasattr(self, 'get_query_set')
+                        else self.get_queryset)
+        return get_queryset()
+
     def live_rules(self):
         """Return enabled rules."""
         rulesets = cache.get(settings.RULESET_CACHE_KEY)
         if rulesets is None:
-            rulesets = self.get_queryset().filter(enabled=True)
+            rulesets = self.get_queryset_compat().filter(enabled=True)
             cache.set(settings.RULESET_CACHE_KEY, rulesets, settings.RULESET_CACHE_TIMEOUT)
         return rulesets
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,32 @@
 [tox]
-envlist = django165_py27, django171_py27
+envlist = django1420_py27, django1512_py27, django1611_py27, django178_py27
 
 [testenv]
 commands=python manage.py test test_app request_profiler
 
 
-[testenv:django165_py27]
+[testenv:django1420_py27]
 basepython = python2.7
 deps =
-    Django==1.6.5
-    South==1.0.1
+    Django==1.4.20
+    South==1.0.2
 
 
-[testenv:django171_py27]
+[testenv:django1512_py27]
 basepython = python2.7
 deps =
-    Django==1.7.1
+    Django==1.5.12
+    South==1.0.2
+
+
+[testenv:django1611_py27]
+basepython = python2.7
+deps =
+    Django==1.6.11
+    South==1.0.2
+
+
+[testenv:django178_py27]
+basepython = python2.7
+deps =
+    Django==1.7.8


### PR DESCRIPTION
Django pre-1.6 doesn't understand models.Manager.get_queryset:

https://docs.djangoproject.com/en/1.8/releases/1.6/#get-query-set-and-similar-methods-renamed-to-get-queryset

Up to you whether you want to merge this or not as it's adding complexity for the sake of supporting something that's almost end-of-life.