### PR TITLE
Enable usage with Django 1.10's MIDDLEWARE setting

### DIFF
--- a/request_profiler/middleware.py
+++ b/request_profiler/middleware.py
@@ -2,6 +2,11 @@
 import logging
 
 from django.contrib.auth.models import AnonymousUser
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Fallback for Django < 1.10
+    MiddlewareMixin = object
 
 from . import settings
 from .models import RuleSet, ProfilingRecord
@@ -10,7 +15,7 @@ from .signals import request_profile_complete
 logger = logging.getLogger(__name__)
 
 
-class ProfilingMiddleware(object):
+class ProfilingMiddleware(MiddlewareMixin):
     """Middleware used to time request-response cycle.
 
     This middleware uses the `process_request` and `process_response`

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -1,4 +1,10 @@
+from distutils.version import StrictVersion
 from os import path
+
+import django
+
+
+DJANGO_VERSION = StrictVersion(django.get_version())
 
 DEBUG = True
 TEMPLATE_DEBUG = True
@@ -23,7 +29,7 @@ INSTALLED_APPS = (
     # 'django_coverage',
 )
 
-MIDDLEWARE_CLASSES = [
+ACTUAL_MIDDLEWARE_CLASSES = [
     # this package's middleware
     'request_profiler.middleware.ProfilingMiddleware',
     # default django middleware
@@ -33,6 +39,12 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 ]
+
+
+if DJANGO_VERSION < StrictVersion('1.10.0'):
+    MIDDLEWARE_CLASSES = ACTUAL_MIDDLEWARE_CLASSES
+else:
+    MIDDLEWARE = ACTUAL_MIDDLEWARE_CLASSES
 
 PROJECT_DIR = path.abspath(path.join(path.dirname(__file__)))
 


### PR DESCRIPTION
While the package was tested under 1.10, it was not tested using the new MIDDLEWARE setting but instead the old MIDDLEWARE_CLASSES setting.

This PR does two things:

a) forces us to use the MIDDLEWARE setting during testing under Django 1.10 and above.

b) utilises Django's MiddlewareMixin so that our Middleware can perform across versions.

Down the line, when MIDDLEWARE_CLASSES is official deprecated we will have to migrate our middleware to the new format. Until then, this will have to be our solution if we are to support old versions.