### PR TITLE
Feature/callable obj support

### DIFF
--- a/request_profiler/middleware.py
+++ b/request_profiler/middleware.py
@@ -42,7 +42,11 @@ class ProfilingMiddleware(MiddlewareMixin):
             settings.STORE_ANONYMOUS_SESSIONS is True
         ):
             request.session.save()
-        request.profiler.view_func_name = view_func.__name__
+
+        if hasattr(view_func, '__name__'):
+            request.profiler.view_func_name = view_func.__name__
+        else:
+            request.profiler.view_func_name = view_func.__class__.__name__
 
     def process_response(self, request, response):
         """Add response information and save the profiler record.

--- a/request_profiler/tests.py
+++ b/request_profiler/tests.py
@@ -18,8 +18,14 @@ from test_app.utils import skipIfDefaultUser
 
 
 def dummy_view_func(request, **kwargs):
-    "Fake function to pass into the process_view method."
+    """Fake function to pass into the process_view method."""
     pass
+
+
+class DummyView(object):
+    """Fake callable object to pass into the process_view method."""
+    def __call__(self, request, **kwargs):
+        pass
 
 
 class MockSession():
@@ -440,6 +446,12 @@ class ProfilingMiddlewareDefaultUserTests(TestCase):
         ProfilingMiddleware().process_view(request, dummy_view_func, [], {})
         self.assertEqual(request.profiler.view_func_name, "dummy_view_func")
 
+    def test_process_view__as_callable_object(self):
+        request = self.factory.get('/')
+        request.profiler = ProfilingRecord()
+        ProfilingMiddleware().process_view(request, DummyView(), [], {})
+        self.assertEqual(request.profiler.view_func_name, "DummyView")
+
     def test_process_response(self):
 
         request = self.factory.get('/')
@@ -564,6 +576,12 @@ class ProfilingMiddlewareCustomUserTests(TestCase):
         request.profiler = ProfilingRecord()
         ProfilingMiddleware().process_view(request, dummy_view_func, [], {})
         self.assertEqual(request.profiler.view_func_name, "dummy_view_func")
+
+    def test_process_view__as_callable_object(self):
+        request = self.factory.get('/')
+        request.profiler = ProfilingRecord()
+        ProfilingMiddleware().process_view(request, DummyView(), [], {})
+        self.assertEqual(request.profiler.view_func_name, "DummyView")
 
     def test_process_response(self):
 

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -42,6 +42,34 @@ class ViewTests(TestCase):
         self.assertEqual(str(record.duration), response['X-Profiler-Duration'])
         self.assertEqual(record.response_status_code, 200)
 
+    def test_rules_match_cbv_view(self):
+        url = reverse('test_cbv')
+        response = self.client.get(url)
+        self.assertTrue(response.has_header('X-Profiler-Duration'))
+        record = ProfilingRecord.objects.get()
+        self.assertIsNone(record.user)
+        self.assertNotEqual(record.session_key, '')
+        self.assertEqual(record.http_user_agent, "")
+        self.assertEqual(record.http_referer, '')
+        self.assertEqual(record.http_method, 'GET')
+        self.assertEqual(record.view_func_name, 'TestView')
+        self.assertEqual(str(record.duration), response['X-Profiler-Duration'])
+        self.assertEqual(record.response_status_code, 200)
+
+    def test_rules_match_callable_view(self):
+        url = reverse('test_callable_view')
+        response = self.client.get(url)
+        self.assertTrue(response.has_header('X-Profiler-Duration'))
+        record = ProfilingRecord.objects.get()
+        self.assertIsNone(record.user)
+        self.assertNotEqual(record.session_key, '')
+        self.assertEqual(record.http_user_agent, "")
+        self.assertEqual(record.http_referer, '')
+        self.assertEqual(record.http_method, 'GET')
+        self.assertEqual(record.view_func_name, 'CallableTestView')
+        self.assertEqual(str(record.duration), response['X-Profiler-Duration'])
+        self.assertEqual(record.response_status_code, 200)
+
     def test_rules_match_view_no_session(self):
         url = reverse('test_view')
         settings.STORE_ANONYMOUS_SESSIONS = False

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 
 from . import views
 
+
 admin.autodiscover()
 
 urlpatterns = [
@@ -20,6 +21,16 @@ urlpatterns = [
         r'^test/404',
         views.test_404,
         name='test_404'
+    ),
+    url(
+        r'^test/class-based-view$',
+        views.TestView.as_view(),
+        name='test_cbv'
+    ),
+    url(
+        r'^test/callable-view$',
+        views.CallableTestView(),
+        name='test_callable_view'
     ),
 
     url(

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,6 +1,11 @@
-
+import django
 from django.shortcuts import render
 from django.http import HttpResponse, Http404
+
+if django.VERSION < (1, 10):
+    from django.views.generic import View
+else:
+    from django.views import View
 
 
 def test_response(request):
@@ -13,3 +18,16 @@ def test_view(request):
 
 def test_404(request):
     raise Http404()
+
+
+class TestView(View):
+    def get(self, request):
+        return HttpResponse('this is a response of CBV')
+
+
+class CallableTestView(object):
+    def __init__(self, response_text='this is a test'):
+        self._response_text = response_text
+
+    def __call__(self, request):
+        return HttpResponse(self._response_text)


### PR DESCRIPTION
Hi everyone,

This PR fixes getting view name in case view is a callable object, see details below:

`__name__` attribute is not presented on objects (only functions and classes).
So for objects which are not functions but implement `__call__` method ``request_profiler`` fails to extract view name (example could be django's feed view `django.contrib.syndication.views.Feed`).

Changes:
- changed `process_view` middleware method
- added tests to `request_profiler` and `test_app`