### PR TITLE
Refactor internals - drop Py37,38

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,8 +37,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python: [3.7,"3.10"]
-                django: [22,32,main]
+                python: [3.9,"3.10"]
+                django: [22,32,40,main]
 
         env:
             TOXENV: py${{ matrix.python }}-django${{ matrix.django }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,7 +38,7 @@ jobs:
         strategy:
             matrix:
                 python: [3.7,"3.10"]
-                django: [22,32,40,main]
+                django: [22,32,main]
 
         env:
             TOXENV: py${{ matrix.python }}-django${{ matrix.django }}

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Django Request Profiler
 =======================
 
-**This package now requires Python3 and Django 2.2 and above.
+**This package now requires Python3.9 and Django 2.2 and above.
 For previous versions please refer to the Python2 branch.**
 
 A very simple request profiler for Django.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
@@ -29,7 +27,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 django = "^2.2 || ^3.0 || ^4.0"
 
 [tool.poetry.dev-dependencies]

--- a/request_profiler/models.py
+++ b/request_profiler/models.py
@@ -216,6 +216,9 @@ class ProfilingRecord(models.Model):
             self.user = request.user
 
     def _extract_view_func_name(self, view_func: Callable) -> str:
+        # the View.as_view() method sets this
+        if hasattr(view_func, "view_class"):
+            return view_func.view_class.__name__  # type:ignore
         return (
             view_func.__name__
             if hasattr(view_func, "__name__")

--- a/request_profiler/models.py
+++ b/request_profiler/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from django.conf import settings as django_settings
 from django.contrib.auth.models import AnonymousUser
@@ -12,6 +12,7 @@ from django.db import connection, models
 from django.db.models.query import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _lazy
 
 from . import settings
 
@@ -20,6 +21,10 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+class BadProfilerError(ValueError):
+    pass
 
 
 class RuleSetQuerySet(models.query.QuerySet):
@@ -172,29 +177,21 @@ class ProfilingRecord(models.Model):
     def __str__(self) -> str:
         return "Profiling record #{}".format(self.pk)
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.is_running = False
+        super().__init__(*args, **kwargs)
+
     def save(self, *args: Any, **kwargs: Any) -> ProfilingRecord:
         super().save(*args, **kwargs)
-        return self
-
-    def start(self) -> ProfilingRecord:
-        """Set start_ts from current datetime."""
-        self.start_ts = timezone.now()
-        self.end_ts = None
-        self.duration = None
-        self.query_count = 0
-        self._query_count = len(connection.queries)
-        self._force_debug_cursor = connection.force_debug_cursor
-        connection.force_debug_cursor = settings.FORCE_DEBUG_CURSOR
         return self
 
     @property
     def elapsed(self) -> float:
         """Time (in seconds) elapsed so far."""
-        if self.start_ts is None:
-            raise ValueError("You must 'start' before you can get elapsed time.")
+        self.check_is_running()
         return (timezone.now() - self.start_ts).total_seconds()
 
-    def set_request(self, request: HttpRequest) -> ProfilingRecord:
+    def process_request(self, request: HttpRequest) -> None:
         """Extract values from HttpRequest and store locally."""
         self.request = request
         self.http_method = request.method
@@ -217,40 +214,64 @@ class ProfilingRecord(models.Model):
         # NB you can't store AnonymouseUsers, so don't bother trying
         if hasattr(request, "user") and request.user.is_authenticated:
             self.user = request.user
-        return self
 
-    def set_response(self, response: HttpResponse) -> ProfilingRecord:
+    def _extract_view_func_name(self, view_func: Callable) -> str:
+        return (
+            view_func.__name__
+            if hasattr(view_func, "__name__")
+            else view_func.__class__.__name__
+        )
+
+    def process_view(self, request: HttpRequest, view_func: Callable) -> None:
+        """Handle the process_view middleware event."""
+        self.view_func_name = self._extract_view_func_name(view_func)
+
+    def process_response(self, response: HttpResponse) -> None:
         """Extract values from HttpResponse and store locally."""
         self.response = response
         self.response_status_code = response.status_code
         self.response_content_length = len(response.content)
+
+    def check_is_running(self) -> ProfilingRecord:
+        """Raise BadProfilerError if profile is not running."""
+        if self.start_ts is None:
+            raise BadProfilerError(_lazy("RequestProfiler has not started."))
+        if not self.is_running:
+            raise BadProfilerError(_lazy("RequestProfiler is no longer running."))
+        return self
+
+    def start(self) -> ProfilingRecord:
+        """Set start_ts from current datetime."""
+        self.is_running = True
+        self.start_ts = timezone.now()
+        self.end_ts = None
+        self.duration = None
+        self.query_count = 0
+        self._query_count = len(connection.queries)
+        self._force_debug_cursor = connection.force_debug_cursor
+        connection.force_debug_cursor = settings.FORCE_DEBUG_CURSOR
         return self
 
     def stop(self) -> ProfilingRecord:
         """Set end_ts and duration from current datetime."""
-        if self.start_ts is None:
-            raise ValueError("You must 'start' before you can 'stop'")
+        self.check_is_running()
         self.end_ts = timezone.now()
         self.duration = (self.end_ts - self.start_ts).total_seconds()
         self.query_count = len(connection.queries) - self._query_count
         connection.force_debug_cursor = self._force_debug_cursor
         if hasattr(self, "response"):
             self.response["X-Profiler-Duration"] = self.duration
+        self.is_running = False
         return self
 
     def cancel(self) -> ProfilingRecord:
-        """Cancel the profile by setting is_cancelled to True."""
+        """Cancel the profile by setting is_running to False."""
         self.start_ts = None
         self.end_ts = None
         self.duration = None
-        self.is_cancelled = True
+        self.is_running = False
         return self
 
     def capture(self) -> ProfilingRecord:
-        """Call stop() and save() on the profile if is_cancelled is False."""
-        if getattr(self, "is_cancelled", False) is True:
-            logger.debug("%r has been cancelled.", self)
-            return self
-        else:
-            self.stop().save()
-            return self
+        """Call stop and save."""
+        return self.check_is_running().stop().save()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,14 +17,14 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE = [
-    # this package's middleware
-    "request_profiler.middleware.ProfilingMiddleware",
     # default django middleware
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
+    # this package's middleware
+    "request_profiler.middleware.ProfilingMiddleware",
 ]
 
 PROJECT_DIR = path.abspath(path.join(path.dirname(__file__)))

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = fmt, lint, mypy, py{3.7,3.8,3.9,3.10}-django{22,30,31,32,40,main}
+envlist = fmt, lint, mypy, py{3.9,3.10}-django{22,30,31,32,40,main}
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR reworks the middleware and changes the names of the
ProfilingRecord model so that they match the middleware methods.
(`set_request` -> `process_request` etc.)

There is a breaking change in the way in which the middleware works, in
that it now follows the middleware structure, `process_request`,
`process_view`, `process_response`, and it no longer passes the request
object to the `process_response` method. It used to do this so that the
request was guaranteed to have the session / user attributes set, even
if the middleware ran after the session / auth middleware (as
`process_response` happens on the way out, so all of the
`process_request` methods will have run by then).

This is convenient, but a hack. In the new world, if you put this
middleware before the django middleware you will not record the session
/ user info, as it won't be set. This is by design. The new
recommendation is that you put this middleware after Django middleware,
as these aren't really optional, and there's very little you can do to
optimise this code. Profile the bits you can edit, ignore the bits you
can't. If Django itself is slowing you down, then that's a whole other
problem.

```python
# settings.py
MIDDLEWARE = [
    # default django middleware
    "django.contrib.sessions.middleware.SessionMiddleware",
    "django.middleware.common.CommonMiddleware",
    "django.middleware.csrf.CsrfViewMiddleware",
    "django.contrib.auth.middleware.AuthenticationMiddleware",
    "django.contrib.messages.middleware.MessageMiddleware",
    # this package's middleware
    "request_profiler.middleware.ProfilingMiddleware",
]
```